### PR TITLE
Implement hamming distance between int32

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This extension supports a set of similarity algorithms. The most known algorithm
   <tr>
     <td>Hamming Distance</td>
     <td>hamming(bit varying, bit varying) returns float8<br/>
+    hamming_int(integer, integer) returns float8<br/>
     hamming_text(text, text) returns float8</td>
     <td>~@~</td>
 	<td>no</td>
@@ -461,4 +462,3 @@ License
 > Neither the name of the Euler Taveira de Oliveira nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/pg_similarity--1.0.sql
+++ b/pg_similarity--1.0.sql
@@ -84,6 +84,14 @@ CREATE FUNCTION hamming_op (varbit, varbit) RETURNS bool
 AS 'MODULE_PATHNAME', 'hamming_op'
 LANGUAGE C STABLE STRICT;
 
+CREATE FUNCTION hamming_int (integer, integer) RETURNS float8
+AS 'MODULE_PATHNAME','hamming_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION hamming_int_op (integer, integer) RETURNS bool
+AS 'MODULE_PATHNAME', 'hamming_int_op'
+LANGUAGE C STABLE STRICT;
+
 CREATE FUNCTION hamming_text (text, text) RETURNS float8
 AS 'MODULE_PATHNAME','hamming_text'
 LANGUAGE C IMMUTABLE STRICT;

--- a/pg_similarity--unpackaged--1.0.sql
+++ b/pg_similarity--unpackaged--1.0.sql
@@ -24,6 +24,8 @@ ALTER EXTENSION pg_similarity ADD operator ~!!(text, text);
 -- Hamming
 ALTER EXTENSION pg_similarity ADD function hamming(varbit, varbit);
 ALTER EXTENSION pg_similarity ADD function hamming_op(varbit, varbit);
+ALTER EXTENSION pg_similarity ADD function hamming_int(integer, integer);
+ALTER EXTENSION pg_similarity ADD function hamming_int_op(integer, integer);
 ALTER EXTENSION pg_similarity ADD function hamming_text(text, text);
 ALTER EXTENSION pg_similarity ADD function hamming_text_op(text, text);
 ALTER EXTENSION pg_similarity ADD operator ~@~(text, text);

--- a/pg_similarity.sql.in
+++ b/pg_similarity.sql.in
@@ -77,15 +77,23 @@ CREATE OPERATOR ~!! (
 
 -- Hamming
 CREATE OR REPLACE FUNCTION hamming (varbit, varbit) RETURNS float8
-AS 'MODULE_PATHNAME','hamming'
+AS 'MODULE_PATHNAME', 'hamming'
 LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION hamming_op (varbit, varbit) RETURNS bool
 AS 'MODULE_PATHNAME', 'hamming_op'
 LANGUAGE C STABLE STRICT;
 
+CREATE OR REPLACE FUNCTION hamming_int (integer, integer) RETURNS float8
+AS 'MODULE_PATHNAME', 'hamming_int'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION hamming_int_op (integer, integer) RETURNS bool
+AS 'MODULE_PATHNAME', 'hamming_int_op'
+LANGUAGE C STABLE STRICT;
+
 CREATE OR REPLACE FUNCTION hamming_text (text, text) RETURNS float8
-AS 'MODULE_PATHNAME','hamming_text'
+AS 'MODULE_PATHNAME', 'hamming_text'
 LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION hamming_text_op (text, text) RETURNS bool

--- a/similarity.h
+++ b/similarity.h
@@ -214,6 +214,8 @@ extern Datum PGS_EXPORT euclidean(PG_FUNCTION_ARGS);
 extern Datum PGS_EXPORT euclidean_op(PG_FUNCTION_ARGS);
 extern Datum PGS_EXPORT hamming(PG_FUNCTION_ARGS);
 extern Datum PGS_EXPORT hamming_op(PG_FUNCTION_ARGS);
+extern Datum PGS_EXPORT hamming_int(PG_FUNCTION_ARGS);
+extern Datum PGS_EXPORT hamming_int_op(PG_FUNCTION_ARGS);
 extern Datum PGS_EXPORT hamming_text(PG_FUNCTION_ARGS);
 extern Datum PGS_EXPORT hamming_text_op(PG_FUNCTION_ARGS);
 extern Datum PGS_EXPORT jaccard(PG_FUNCTION_ARGS);

--- a/uninstall_pg_similarity.sql
+++ b/uninstall_pg_similarity.sql
@@ -22,6 +22,8 @@ DROP FUNCTION euclidean_op (text, text);
 DROP OPERATOR ~@~ (text, text);
 DROP FUNCTION hamming_text (text, text);
 DROP FUNCTION hamming_text_op (text, text);
+DROP FUNCTION hamming_int (integer, integer);
+DROP FUNCTION hamming_int_op (integer, integer);
 DROP FUNCTION hamming (varbit, varbit);
 DROP FUNCTION hamming_op (varbit, varbit);
 


### PR DESCRIPTION
This PR adds native support for hamming distance between two integers. As ints we can use `__builtin_popcount` which gives considerable performance improvements. @eulerto this is something I needed, posting it in case you think it's generally useful and would like to include.