### PR TITLE
Fix soundex non-alpha detection

### DIFF
--- a/soundex.c
+++ b/soundex.c
@@ -56,7 +56,7 @@ static char *_soundex(char *a)
 	while (!isalpha(*a) && *a != '\0')
 		a++;
 
-	if (*a != '\0')
+	if (*a == '\0')
 		elog(ERROR, "string doesn't contain non-alpha character(s)");
 
 	/* get the first letter */


### PR DESCRIPTION
adacf8ab8f6ed8304ff4c5dcffbf0378656091e1 broke the non-alpha character
string parsing by inverting the logic.