### PR TITLE
Test extension

### DIFF
--- a/expected/test1.out
+++ b/expected/test1.out
@@ -2,12 +2,7 @@
 -- pg_similarity
 -- testing similarity functions and operators
 --
---
--- Turn off echoing so that expected file does not depend on contents of
--- this file
---
-SET client_min_messages to warning;
-\set ECHO none
+CREATE EXTENSION pg_similarity;
 \set a '\'Euler Taveira de Oliveira\''
 \set b '\'Euler T Oliveira\''
 \set c '\'Oiler Taviera do Oliviera\''

--- a/expected/test2.out
+++ b/expected/test2.out
@@ -7,6 +7,7 @@
 --
 RESET client_min_messages;
 \set ECHO all
+LOAD 'pg_similarity';
 --
 -- errors
 --

--- a/expected/test3.out
+++ b/expected/test3.out
@@ -21,12 +21,6 @@ INSERT INTO simtst (a) VALUES
 ('Oliveira, E. T.'),
 ('ETO');
 -- Levenshtein
-SHOW pg_similarity.levenshtein_threshold;
- pg_similarity.levenshtein_threshold 
--------------------------------------
- 0.7
-(1 row)
-
 SELECT a FROM simtst WHERE a ~== :a;
              a             
 ---------------------------
@@ -35,6 +29,12 @@ SELECT a FROM simtst WHERE a ~== :a;
  Euler T. de Oliveira
  EULER TAVEIRA OLIVEIRA
 (4 rows)
+
+SHOW pg_similarity.levenshtein_threshold;
+ pg_similarity.levenshtein_threshold 
+-------------------------------------
+ 0.7
+(1 row)
 
 SET pg_similarity.levenshtein_threshold to 0.4;
 SHOW pg_similarity.levenshtein_threshold;

--- a/pg_similarity--1.0.sql
+++ b/pg_similarity--1.0.sql
@@ -174,13 +174,13 @@ CREATE OPERATOR ~== (
 );
 
 -- Those functions are here just for academic purposes
---CREATE FUNCTION levslow (text, text) RETURNS float8
---AS 'MODULE_PATHNAME','levslow'
---LANGUAGE C IMMUTABLE STRICT;
+CREATE FUNCTION levslow (text, text) RETURNS float8
+AS 'MODULE_PATHNAME','levslow'
+LANGUAGE C IMMUTABLE STRICT;
 
---CREATE FUNCTION levslow_op (text, text) RETURNS bool
---AS 'MODULE_PATHNAME', 'levslow_op'
---LANGUAGE C STABLE STRICT;
+CREATE FUNCTION levslow_op (text, text) RETURNS bool
+AS 'MODULE_PATHNAME', 'levslow_op'
+LANGUAGE C STABLE STRICT;
 
 --CREATE OPERATOR ~@@ (
 --	LEFTARG = text,

--- a/sql/test1.sql
+++ b/sql/test1.sql
@@ -3,15 +3,7 @@
 -- testing similarity functions and operators
 --
 
---
--- Turn off echoing so that expected file does not depend on contents of
--- this file
---
-SET client_min_messages to warning;
-\set ECHO none
-\i pg_similarity.sql
-RESET client_min_messages;
-\set ECHO all
+CREATE EXTENSION pg_similarity;
 
 \set a '\'Euler Taveira de Oliveira\''
 \set b '\'Euler T Oliveira\''

--- a/sql/test2.sql
+++ b/sql/test2.sql
@@ -9,6 +9,8 @@
 RESET client_min_messages;
 \set ECHO all
 
+LOAD 'pg_similarity';
+
 --
 -- errors
 --

--- a/sql/test3.sql
+++ b/sql/test3.sql
@@ -26,8 +26,8 @@ INSERT INTO simtst (a) VALUES
 ('ETO');
 
 -- Levenshtein
-SHOW pg_similarity.levenshtein_threshold;
 SELECT a FROM simtst WHERE a ~== :a;
+SHOW pg_similarity.levenshtein_threshold;
 SET pg_similarity.levenshtein_threshold to 0.4;
 SHOW pg_similarity.levenshtein_threshold;
 SELECT a FROM simtst WHERE a ~== :a;


### PR DESCRIPTION
This commit makes "make installcheck" use the actually installed
extension. In test1, we CREATE EXTENSION. In test2, we need to LOAD
'pg_similarity' because pg_regress opens a new session per test, and the
SET error is only triggered if the .so file is already loaded. test3 has
a similar problem, but here the easiest fix is to call a function first
before using SHOW.

I've created Debian packages for pg_similarity on apt.postgresql.org, and these patches made the regression tests pass there.