### PR TITLE
Update description of pg_similarity.jarowinkler_threshold to say Jaro-Winkler instead of Jaro

### DIFF
--- a/similarity.c
+++ b/similarity.c
@@ -410,7 +410,7 @@ _PG_init(void)
 
 	/* Jaro-Winkler */
 	DefineCustomRealVariable("pg_similarity.jarowinkler_threshold",
-							 "Sets the threshold used by the Jaro similarity measure.",
+							 "Sets the threshold used by the Jaro-Winkler similarity measure.",
 							 "Valid range is 0.0 .. 1.0.",
 							 &pgs_jarowinkler_threshold,
 							 0.7,


### PR DESCRIPTION
The GUC description appears to be incorrect as it says Jaro instead of Jaro-Winkler. (Jaro description is already used on line 385)