### PR TITLE
Fixing tests to ensure that make installcheck works

### DIFF
--- a/expected/test2.out
+++ b/expected/test2.out
@@ -2,7 +2,10 @@
 -- errors
 --
 SET pg_similarity.cosine_threshold to 1.1;
+ERROR:  1.1 is outside the valid range for parameter "pg_similarity.cosine_threshold" (0 .. 1)
 SET pg_similarity.qgram_tokenizer to 'alnum';
+ERROR:  invalid value for parameter "pg_similarity.qgram_tokenizer": "alnum"
+HINT:  Available values: gram.
 --
 -- valid values
 --
@@ -10,5 +13,5 @@ SET pg_similarity.block_is_normalized to true;
 SET pg_similarity.cosine_threshold = 0.72;
 SET pg_similarity.dice_tokenizer to 'alnum';
 SET pg_similarity.euclidean_is_normalized to false;
-SET pg_similarity.jaro_winkler_is_normalized to false;
+SET pg_similarity.jarowinkler_is_normalized to false;
 SET pg_similarity.qgram_tokenizer to 'gram';

--- a/expected/test2.out
+++ b/expected/test2.out
@@ -1,3 +1,4 @@
+LOAD 'pg_similarity';
 --
 -- errors
 --

--- a/pg_similarity.conf.sample
+++ b/pg_similarity.conf.sample
@@ -78,7 +78,7 @@
 #pg_similarity.overlap_is_normalized = true
 
 # - Q-Gram -
-#pg_similarity.qgram_tokenizer = 'qgram'
+#pg_similarity.qgram_tokenizer = 'gram'
 #pg_similarity.qgram_threshold = 0.7
 #pg_similarity.qgram_is_normalized = true
 

--- a/sql/test2.sql
+++ b/sql/test2.sql
@@ -11,5 +11,5 @@ SET pg_similarity.block_is_normalized to true;
 SET pg_similarity.cosine_threshold = 0.72;
 SET pg_similarity.dice_tokenizer to 'alnum';
 SET pg_similarity.euclidean_is_normalized to false;
-SET pg_similarity.jaro_winkler_is_normalized to false;
+SET pg_similarity.jarowinkler_is_normalized to false;
 SET pg_similarity.qgram_tokenizer to 'gram';

--- a/sql/test2.sql
+++ b/sql/test2.sql
@@ -1,3 +1,5 @@
+LOAD 'pg_similarity';
+
 --
 -- errors
 --


### PR DESCRIPTION
Hi! I ran the unit tests for this extension and realized that test2 failed. This is mainly due to the lack of error messages and the misspelling of the bool variable pg_similarity.jarowinkler_is_normalized in the unit test. I have fixed these and the unit tests now pass. I was running this code on an Ubuntu instance with PostgreSQL 15.3.