### PR TITLE
Fix GUC boot values

### DIFF
--- a/block.c
+++ b/block.c
@@ -38,7 +38,7 @@
 
 /* GUC variables */
 int		pgs_block_tokenizer = PGS_UNIT_ALNUM;
-double	pgs_block_threshold = 0.7f;
+double	pgs_block_threshold = 0.7;
 bool	pgs_block_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(block);

--- a/cosine.c
+++ b/cosine.c
@@ -21,7 +21,7 @@
 
 /* GUC variables */
 int		pgs_cosine_tokenizer = PGS_UNIT_ALNUM;
-double	pgs_cosine_threshold = 0.7f;
+double	pgs_cosine_threshold = 0.7;
 bool	pgs_cosine_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(cosine);

--- a/dice.c
+++ b/dice.c
@@ -34,7 +34,7 @@
 
 /* GUC variables */
 int		pgs_dice_tokenizer = PGS_UNIT_ALNUM;
-double	pgs_dice_threshold = 0.7f;
+double	pgs_dice_threshold = 0.7;
 bool	pgs_dice_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(dice);

--- a/euclidean.c
+++ b/euclidean.c
@@ -40,7 +40,7 @@
 
 /* GUC variables */
 int		pgs_euclidean_tokenizer = PGS_UNIT_ALNUM;
-double	pgs_euclidean_threshold = 0.7f;
+double	pgs_euclidean_threshold = 0.7;
 bool	pgs_euclidean_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(euclidean);

--- a/hamming.c
+++ b/hamming.c
@@ -34,7 +34,7 @@
 
 
 /* GUC variables */
-double	pgs_hamming_threshold = 0.7f;
+double	pgs_hamming_threshold = 0.7;
 bool	pgs_hamming_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(hamming);

--- a/jaccard.c
+++ b/jaccard.c
@@ -34,7 +34,7 @@
 
 /* GUC variables */
 int		pgs_jaccard_tokenizer = PGS_UNIT_ALNUM;
-double	pgs_jaccard_threshold = 0.7f;
+double	pgs_jaccard_threshold = 0.7;
 bool	pgs_jaccard_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(jaccard);

--- a/jaro.c
+++ b/jaro.c
@@ -60,9 +60,9 @@
 #include <math.h>
 
 /* GUC variables */
-double	pgs_jaro_threshold = 0.7f;
+double	pgs_jaro_threshold = 0.7;
 bool	pgs_jaro_is_normalized = true;
-double	pgs_jarowinkler_threshold = 0.7f;
+double	pgs_jarowinkler_threshold = 0.7;
 bool	pgs_jarowinkler_is_normalized = true;
 
 

--- a/levenshtein.c
+++ b/levenshtein.c
@@ -43,7 +43,7 @@
 
 
 /* GUC variables */
-double	pgs_levenshtein_threshold = 0.7f;
+double	pgs_levenshtein_threshold = 0.7;
 bool	pgs_levenshtein_is_normalized = true;
 
 

--- a/matching.c
+++ b/matching.c
@@ -34,7 +34,7 @@
 
 /* GUC variables */
 int		pgs_matching_tokenizer = PGS_UNIT_ALNUM;
-double	pgs_matching_threshold = 0.7f;
+double	pgs_matching_threshold = 0.7;
 bool	pgs_matching_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(matchingcoefficient);

--- a/mongeelkan.c
+++ b/mongeelkan.c
@@ -13,7 +13,7 @@
 
 /* GUC variables */
 int		pgs_mongeelkan_tokenizer = PGS_UNIT_ALNUM;
-double	pgs_mongeelkan_threshold = 0.7f;
+double	pgs_mongeelkan_threshold = 0.7;
 bool	pgs_mongeelkan_is_normalized = true;
 
 /*

--- a/needlemanwunsch.c
+++ b/needlemanwunsch.c
@@ -61,9 +61,9 @@
 
 
 /* GUC variables */
-double	pgs_nw_threshold = 0.7f;
+double	pgs_nw_threshold = 0.7;
 bool	pgs_nw_is_normalized = true;
-double	pgs_nw_gap_penalty = -5.0f;
+double	pgs_nw_gap_penalty = -5.0;
 
 
 static int _nwunsch(char *a, char *b, int gap)

--- a/overlap.c
+++ b/overlap.c
@@ -34,7 +34,7 @@
 
 /* GUC variables */
 int		pgs_overlap_tokenizer = PGS_UNIT_ALNUM;
-double	pgs_overlap_threshold = 0.7f;
+double	pgs_overlap_threshold = 0.7;
 bool	pgs_overlap_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(overlapcoefficient);

--- a/qgram.c
+++ b/qgram.c
@@ -32,7 +32,7 @@
 
 /* GUC variables */
 int		pgs_qgram_tokenizer = PGS_UNIT_GRAM;
-double	pgs_qgram_threshold = 0.7f;
+double	pgs_qgram_threshold = 0.7;
 bool	pgs_qgram_is_normalized = true;
 
 PG_FUNCTION_INFO_V1(qgram);

--- a/smithwaterman.c
+++ b/smithwaterman.c
@@ -66,7 +66,7 @@
 
 
 /* GUC variables */
-double	pgs_sw_threshold = 0.7f;
+double	pgs_sw_threshold = 0.7;
 bool	pgs_sw_is_normalized = true;
 
 /*

--- a/smithwatermangotoh.c
+++ b/smithwatermangotoh.c
@@ -9,7 +9,7 @@
 
 #include "similarity.h"
 
-double	pgs_swg_threshold = 0.7f;
+double	pgs_swg_threshold = 0.7;
 bool	pgs_swg_is_normalized = true;
 
 /*


### PR DESCRIPTION
Fixes assertion failures on cassert-enabled PG16.

```
LOG:  GUC (PGC_REAL) pg_similarity.euclidean_threshold, boot_val=0.7, C-var=0.7
STATEMENT:  CREATE EXTENSION pg_similarity;
TRAP: failed Assert("check_GUC_init(variable)"), File: "./build/../src/backend/utils/misc/guc.c", Line: 4764, PID: 779990
```

(Fix developed against 1.0 - please do tag a new version, 1.0 is quite old!)

Close: #39